### PR TITLE
update standardize binstub to correctly run prettier

### DIFF
--- a/bin/standardize
+++ b/bin/standardize
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+echo "======== running standardrb ========"
 bundle exec standardrb --fix
-prettier --write app/**/*.js
+echo "======== running prettier ========"
+yarn prettier-fix

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,7 +15,7 @@ module StimulusReflexTodomvc
     # helpers, and stylesheets will not be created
     config.generators do |g|
       g.template_engine nil
-      g.test_framework  nil
+      g.test_framework nil
       g.assets false
       g.helper false
       g.stylesheets false


### PR DESCRIPTION
With the state of the current binstub, you will get this error if you do not have prettier installed

`bin/standardize: line 4: prettier: command not found`

This will resolve this.