### PR TITLE
Fix session separation by using rooms

### DIFF
--- a/app/views/todos/_filters.html.erb
+++ b/app/views/todos/_filters.html.erb
@@ -5,18 +5,18 @@
 
   <ul class="filters">
     <li>
-      <%= link_to "All", "#", class: filter_css(:all), data: { reflex: "click->TodosReflex#filter", filter: "all" } %>
+      <%= link_to "All", "#", class: filter_css(:all), data: { reflex: "click->TodosReflex#filter", room: session.id, filter: "all" } %>
     </li>
     <li>
-      <%= link_to "Active", "#", class: filter_css(:active), data: { reflex: "click->TodosReflex#filter", filter: "active" } %>
+      <%= link_to "Active", "#", class: filter_css(:active), data: { reflex: "click->TodosReflex#filter", room: session.id, filter: "active" } %>
     </li>
     <li>
-      <%= link_to "Completed", "#", class: filter_css(:completed), data: { reflex: "click->TodosReflex#filter", filter: "completed" } %>
+      <%= link_to "Completed", "#", class: filter_css(:completed), data: { reflex: "click->TodosReflex#filter", room: session.id, filter: "completed" } %>
     </li>
   </ul>
 
   <% if @all_todos.completed.any? %>
-    <button class="clear-completed" data-reflex="click->TodosReflex#destroy_completed">
+    <button class="clear-completed" data-reflex="click->TodosReflex#destroy_completed" data-room="<%= session.id %>">
       Clear completed
     </button>
   <% end %>

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -2,17 +2,17 @@
   <li class="editing">
     <input autofocus type="text" class="edit" value="<%= todo.title %>"
       data-action="keydown->todos#cancelEdit blur->todos#cancelEdit"
-      data-reflex="change->TodosReflex#update" data-id="<%= todo.id %>">
+      data-reflex="change->TodosReflex#update" data-id="<%= todo.id %>" data-room="<%= session.id %>">
   </li>
 <% else %>
   <li class="<%= "completed" if todo.completed? %>"
-      data-reflex="click->TodosReflex#edit" data-id="<%= todo.id %>">
+      data-reflex="click->TodosReflex#edit" data-id="<%= todo.id %>" data-room="<%= session.id %>">
     <div class="view">
-      <input <%= "checked" if todo.completed? %> type="checkbox" class="toggle" data-reflex="change->TodosReflex#toggle" data-id="<%= todo.id %>">
+      <input <%= "checked" if todo.completed? %> type="checkbox" class="toggle" data-reflex="change->TodosReflex#toggle" data-id="<%= todo.id %>" data-room="<%= session.id %>">
       <label>
         <%= todo.title %>
       </label>
-      <button name="button" type="button" class="destroy" data-reflex="click->TodosReflex#destroy" data-id="<%= todo.id %>"/>
+      <button name="button" type="button" class="destroy" data-reflex="click->TodosReflex#destroy" data-id="<%= todo.id %>" data-room="<%= session.id %>"/>
     </div>
   </li>
 <% end %>

--- a/app/views/todos/index.html.erb
+++ b/app/views/todos/index.html.erb
@@ -3,13 +3,13 @@
     <h1>
       todos
     </h1>
-    <input <%= "autofocus " unless @edit_id %>class="new-todo" placeholder="What needs to be done?" data-reflex="change->TodosReflex#create">
+    <input <%= "autofocus " unless @edit_id %>class="new-todo" placeholder="What needs to be done?" data-reflex="change->TodosReflex#create" data-room="<%= session.id %>">
   </header>
 
   <% if @all_todos.any? %>
     <section class="main">
       <input class="toggle-all" type="checkbox">
-      <label data-reflex="click->TodosReflex#toggle_all">
+      <label data-reflex="click->TodosReflex#toggle_all" data-room="<%= session.id %>">
         Mark all as complete
       </label>
       <ul class="todo-list">


### PR DESCRIPTION
Currently, every browser instance (session) sees its **own** data at startup, but any changes will be sent to **all** instances. I don't think this is intended, so I made a small fix by using [rooms](https://github.com/hopsoft/stimulus_reflex#actioncable-rooms).