### PR TITLE
added missing meta tag to support cable urls

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <title>StimulusReflexTodomvc</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= action_cable_meta_tag %>
 
     <%# stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>


### PR DESCRIPTION
Rails provides a helper to include information about your websockets server that gets picked up by ActionCable. Right now, the app is working because of logical defaults.

For example, add this to **config/environments/development.rb**:

`config.action_cable.url = "ws://localhost:3334/cable"`

In **app/views/layouts/application.html.erb** insert:

`<%= action_cable_meta_tag %>`

Your HTML markup will now contain:

`<meta name="action-cable-url" content="ws://localhost:3334/cable" />`