### PR TITLE
remove duplicate prettier configuration file

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,8 +1,0 @@
-bracketSpacing: true
-printWidth: 110
-requirePragma: false
-semi: true
-singleQuote: true
-tabWidth: 2
-trailingComma: es5
-useTabs: false


### PR DESCRIPTION
looks like we have two prettier config files. This commit removes `.prettierrc.yml` in favor of the new standard `prettier.config.js`.