### PR TITLE
Procfile bikeshed is now blue

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,1 +1,2 @@
 web: bundle exec puma -C config/puma.rb
+webpack: bin/webpack-dev-server


### PR DESCRIPTION
Many apologies for the churn. I completely forgot that Heroku used Procfiles, too.

The solution I've arrived at is two-fold:

1. export PORT=3000 in my shell login script
2. created a Procfile.dev for local development

Procfile itself is now back to the way it was before I started trying to reinvent.